### PR TITLE
go.mod needed as of Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/florianmoss/hello
+
+go 1.11

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/florianmoss/hello
+module github.com/openshift-for-developers/hello
 
-go 1.11
+go 1.16

--- a/hello-openshift-for-developers.go
+++ b/hello-openshift-for-developers.go
@@ -9,7 +9,7 @@ import (
 func helloHandler(w http.ResponseWriter, r *http.Request) {
 	response := os.Getenv("RESPONSE")
 	if len(response) == 0 {
-		response = "Hello OpenShift for Developers!"
+		response = "Hello world!"
 	}
 
 	fmt.Fprintln(w, response)

--- a/hello-openshift-for-developers.go
+++ b/hello-openshift-for-developers.go
@@ -9,7 +9,7 @@ import (
 func helloHandler(w http.ResponseWriter, r *http.Request) {
 	response := os.Getenv("RESPONSE")
 	if len(response) == 0 {
-		response = "Hello world!"
+		response = "Hello OpenShift for Developers!"
 	}
 
 	fmt.Fprintln(w, response)


### PR DESCRIPTION
As of Go 1.16, the go.mod file is required, otherwise the build fails.